### PR TITLE
fix enter key label spelling of arayn to use pasekh-tsvey-yudn

### DIFF
--- a/src/components/keyboard/Keyboard.tsx
+++ b/src/components/keyboard/Keyboard.tsx
@@ -78,7 +78,7 @@ export const Keyboard = ({ onChar, onDelete, onEnter, guesses }: Props) => {
       </div>
       <div className="flex justify-center flex-row-reverse">
         <Key width={65.4} value="ENTER" onClick={onClick}>
-          אַרייַן
+          אַרײַן
         </Key>
         <Key value="תּ" onClick={onClick} status={charStatuses['תּ']} />
         <Key value="ױ" onClick={onClick} status={charStatuses['ױ']} />


### PR DESCRIPTION
Enter key had a defectively encoded spelling of *arayn*. 

Was: `אַרייַן`

Now: `אַרײַן`

The pasekh diacritic must be combined with a double-yud digraph character (ײ), not just with one or the other single yud (י) characters.